### PR TITLE
implemented optional number of workers for parallel scaling and optimization

### DIFF
--- a/paref/interfaces/moo_algorithms/blackbox_function.py
+++ b/paref/interfaces/moo_algorithms/blackbox_function.py
@@ -221,6 +221,18 @@ class BlackboxFunction:
         """
         return False
 
+    @property
+    def n_workers(self) -> int:
+        """Number of workers for parallel scaling and optimization
+
+        Returns
+        -------
+        int
+            number of workers for parallel scaling and optimization
+
+        """
+        return 1
+
     def perform_lhc(self, n: int) -> None:
         """Perform Latin Hypercube Sampling
 


### PR DESCRIPTION
Replaced lambda functions with class wrappers, their location might be suboptimal.
Users can implement the n_workers property, to use n or -1 threads in a managed threadpool.
Re-run juypter notebooks, to test the property for reflection sequences with more than 1 reflection.